### PR TITLE
Add support for `force` configuration option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,7 @@
 	"maxparams": 10,
 	"maxdepth": 3,
 	"maxstatements": 50,
-	"maxcomplexity": 12,
+	"maxcomplexity": 13,
 	"debug": true,
 	"smarttabs": true,
 	"browser": true,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ var browserStackTunnel = new BrowserStackTunnel({
   proxyUser: PROXY_USER, // optionally set the -proxyUser option
   proxyPass: PROXY_PASS, // optionally set the -proxyPass option
   proxyPort: PROXY_PORT, // optionally set the -proxyPort option
-  proxyHost: PROXY_HOST // optionally set the -proxyHost option
+  proxyHost: PROXY_HOST, // optionally set the -proxyHost option
+  force: false // optionally set the -force option
 });
 
 browserStackTunnel.start(function(error) {

--- a/src/BrowserStackTunnel.js
+++ b/src/BrowserStackTunnel.js
@@ -53,6 +53,10 @@ function BrowserStackTunnel(options) {
     params.push('-v');
   }
 
+  if (options.force) {
+    params.push('-force');
+  }
+
   if (options.proxyHost) {
     params.push('-proxyHost', options.proxyHost);
   }

--- a/test/src/BrowserStackTunnel.js
+++ b/test/src/BrowserStackTunnel.js
@@ -390,6 +390,40 @@ describe('BrowserStackTunnel', function () {
     }, 100);
   });
 
+  it('should support the force option', function (done) {
+    spawnSpy.reset();
+    var browserStackTunnel = new bs.BrowserStackTunnel({
+      key: KEY,
+      hosts: [{
+        name: HOST_NAME,
+        port: PORT,
+        sslFlag: SSL_FLAG
+      }],
+      force: true,
+      win32Bin: WIN32_BINARY_DIR
+    });
+    browserStackTunnel.start(function (error) {
+      if (error) {
+        expect().fail(function () { return error; });
+      } else if (browserStackTunnel.state === 'started') {
+        sinon.assert.calledOnce(spawnSpy);
+        sinon.assert.calledWithExactly(
+          spawnSpy,
+          WIN32_BINARY_FILE, [
+            KEY,
+            HOST_NAME + ',' + PORT + ',' + SSL_FLAG,
+            '-force'
+          ]
+        );
+        done();
+      }
+    });
+
+    setTimeout(function () {
+      process.emit('mock:child_process:stdout:data', 'monkey-----  Press Ctrl-C to exit ----monkey');
+    }, 100);
+  });
+
   it('should support the skipCheck option', function (done) {
     spawnSpy.reset();
     var browserStackTunnel = new bs.BrowserStackTunnel({


### PR DESCRIPTION
This is an option I find in version 2.2 to "Kill other running Browserstack Local".

Also had to bump jshint maxcomplexity.
