### PR TITLE
Update supported options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -21,7 +21,7 @@
 	"maxparams": 10,
 	"maxdepth": 3,
 	"maxstatements": 50,
-	"maxcomplexity": 13,
+	"maxcomplexity": 15,
 	"debug": true,
 	"smarttabs": true,
 	"browser": true,

--- a/README.md
+++ b/README.md
@@ -25,19 +25,20 @@ var browserStackTunnel = new BrowserStackTunnel({
     name: 'localhost',
     port: 8080,
     sslFlag: 0
-  }],
+  }], // optionally set hosts
   osxBin: 'your_bin_dir', // optionally override the default bin directory for the OSX binary
   linux32Bin: 'your_bin_dir', // optionally override the default bin directory for the Linux 32 bit binary
   linux64Bin: 'your_bin_dir', // optionally override the default bin directory for the Linux 64 bit binary
   win32Bin: 'your_bin_dir', // optionally override the default bin directory for the win32 binary
-  tunnelIdentifier: 'my_tunnel', // optionally set the -tunnelIdentifier option
-  skipCheck: true, // optionally set the -skipCheck option
+  localIdentifier: 'my_tunnel', // optionally set the -localIdentifier option
   v: true, // optionally set the -v (verbose) option
   proxyUser: PROXY_USER, // optionally set the -proxyUser option
   proxyPass: PROXY_PASS, // optionally set the -proxyPass option
   proxyPort: PROXY_PORT, // optionally set the -proxyPort option
   proxyHost: PROXY_HOST, // optionally set the -proxyHost option
-  force: false // optionally set the -force option
+  force: false, // optionally set the -force option
+  forcelocal: false, // optionally set the -forcelocal option
+  onlyAutomate: false, // optionally set the -onlyAutomate option
 });
 
 browserStackTunnel.start(function(error) {

--- a/src/BrowserStackTunnel.js
+++ b/src/BrowserStackTunnel.js
@@ -32,21 +32,19 @@ function BrowserStackTunnel(options) {
   this.stdoutData = '';
   this.tunnel = null;
 
-  var hosts = '';
-  options.hosts.forEach(function (host) {
-    if (hosts.length > 0) {
-      hosts += ',';
-    }
-    hosts += host.name + ',' + host.port + ',' + host.sslFlag;
-  });
-  params.push(hosts);
-
-  if (options.tunnelIdentifier) {
-    params.push('-tunnelIdentifier', options.tunnelIdentifier);
+  if (options.hosts) {
+    var hosts = '';
+    options.hosts.forEach(function (host) {
+      if (hosts.length > 0) {
+        hosts += ',';
+      }
+      hosts += host.name + ',' + host.port + ',' + host.sslFlag;
+    });
+    params.push(hosts);
   }
 
-  if (options.skipCheck) {
-    params.push('-skipCheck');
+  if (options.localIdentifier) {
+    params.push('-localIdentifier', options.localIdentifier);
   }
 
   if (options.v) {
@@ -55,6 +53,14 @@ function BrowserStackTunnel(options) {
 
   if (options.force) {
     params.push('-force');
+  }
+
+  if (options.forcelocal) {
+    params.push('-forcelocal');
+  }
+
+  if (options.onlyAutomate) {
+    params.push('-onlyAutomate');
   }
 
   if (options.proxyHost) {

--- a/test/src/BrowserStackTunnel.js
+++ b/test/src/BrowserStackTunnel.js
@@ -254,6 +254,32 @@ describe('BrowserStackTunnel', function () {
     }, 100);
   });
 
+  it('should support no hosts', function (done) {
+    spawnSpy.reset();
+    var browserStackTunnel = new bs.BrowserStackTunnel({
+      key: KEY,
+      win32Bin: WIN32_BINARY_DIR
+    });
+    browserStackTunnel.start(function (error) {
+      if (error) {
+        expect().fail(function () { return error; });
+      } else if (browserStackTunnel.state === 'started') {
+        sinon.assert.calledOnce(spawnSpy);
+        sinon.assert.calledWithExactly(
+          spawnSpy,
+          WIN32_BINARY_FILE, [
+            KEY,
+          ]
+        );
+        done();
+      }
+    });
+
+    setTimeout(function () {
+      process.emit('mock:child_process:stdout:data', 'monkey-----  Press Ctrl-C to exit ----monkey');
+    }, 100);
+  });
+
   it('should use the specified binary directory', function (done) {
     spawnSpy.reset();
     var browserStackTunnel = new bs.BrowserStackTunnel({
@@ -262,7 +288,7 @@ describe('BrowserStackTunnel', function () {
         name: HOST_NAME,
         port: PORT,
         sslFlag: SSL_FLAG,
-        tunnelIdentifier: 'my_tunnel'
+        localIdentifier: 'my_tunnel'
       }],
       win32Bin: WIN32_BINARY_DIR
     });
@@ -287,7 +313,7 @@ describe('BrowserStackTunnel', function () {
     }, 100);
   });
 
-  it('should support the tunnelIdentifier option', function (done) {
+  it('should support the localIdentifier option', function (done) {
     spawnSpy.reset();
     var browserStackTunnel = new bs.BrowserStackTunnel({
       key: KEY,
@@ -296,7 +322,7 @@ describe('BrowserStackTunnel', function () {
         port: PORT,
         sslFlag: SSL_FLAG
       }],
-      tunnelIdentifier: 'my_tunnel',
+      localIdentifier: 'my_tunnel',
       win32Bin: WIN32_BINARY_DIR
     });
     browserStackTunnel.start(function (error) {
@@ -309,42 +335,8 @@ describe('BrowserStackTunnel', function () {
           WIN32_BINARY_FILE, [
             KEY,
             HOST_NAME + ',' + PORT + ',' + SSL_FLAG,
-            '-tunnelIdentifier',
+            '-localIdentifier',
             'my_tunnel'
-          ]
-        );
-        done();
-      }
-    });
-
-    setTimeout(function () {
-      process.emit('mock:child_process:stdout:data', 'monkey-----  Press Ctrl-C to exit ----monkey');
-    }, 100);
-  });
-
-  it('should support the skipCheck option', function (done) {
-    spawnSpy.reset();
-    var browserStackTunnel = new bs.BrowserStackTunnel({
-      key: KEY,
-      hosts: [{
-        name: HOST_NAME,
-        port: PORT,
-        sslFlag: SSL_FLAG
-      }],
-      skipCheck: true,
-      win32Bin: WIN32_BINARY_DIR
-    });
-    browserStackTunnel.start(function (error) {
-      if (error) {
-        expect().fail(function () { return error; });
-      } else if (browserStackTunnel.state === 'started') {
-        sinon.assert.calledOnce(spawnSpy);
-        sinon.assert.calledWithExactly(
-          spawnSpy,
-          WIN32_BINARY_FILE, [
-            KEY,
-            HOST_NAME + ',' + PORT + ',' + SSL_FLAG,
-            '-skipCheck'
           ]
         );
         done();
@@ -424,7 +416,7 @@ describe('BrowserStackTunnel', function () {
     }, 100);
   });
 
-  it('should support the skipCheck option', function (done) {
+  it('should support the forcelocal option', function (done) {
     spawnSpy.reset();
     var browserStackTunnel = new bs.BrowserStackTunnel({
       key: KEY,
@@ -433,7 +425,7 @@ describe('BrowserStackTunnel', function () {
         port: PORT,
         sslFlag: SSL_FLAG
       }],
-      skipCheck: true,
+      forcelocal: true,
       win32Bin: WIN32_BINARY_DIR
     });
     browserStackTunnel.start(function (error) {
@@ -446,7 +438,41 @@ describe('BrowserStackTunnel', function () {
           WIN32_BINARY_FILE, [
             KEY,
             HOST_NAME + ',' + PORT + ',' + SSL_FLAG,
-            '-skipCheck'
+            '-forcelocal'
+          ]
+        );
+        done();
+      }
+    });
+
+    setTimeout(function () {
+      process.emit('mock:child_process:stdout:data', 'monkey-----  Press Ctrl-C to exit ----monkey');
+    }, 100);
+  });
+
+  it('should support the onlyAutomate option', function (done) {
+    spawnSpy.reset();
+    var browserStackTunnel = new bs.BrowserStackTunnel({
+      key: KEY,
+      hosts: [{
+        name: HOST_NAME,
+        port: PORT,
+        sslFlag: SSL_FLAG
+      }],
+      onlyAutomate: true,
+      win32Bin: WIN32_BINARY_DIR
+    });
+    browserStackTunnel.start(function (error) {
+      if (error) {
+        expect().fail(function () { return error; });
+      } else if (browserStackTunnel.state === 'started') {
+        sinon.assert.calledOnce(spawnSpy);
+        sinon.assert.calledWithExactly(
+          spawnSpy,
+          WIN32_BINARY_FILE, [
+            KEY,
+            HOST_NAME + ',' + PORT + ',' + SSL_FLAG,
+            '-onlyAutomate'
           ]
         );
         done();
@@ -571,7 +597,7 @@ describe('BrowserStackTunnel', function () {
           name: HOST_NAME,
           port: PORT,
           sslFlag: SSL_FLAG,
-          tunnelIdentifier: 'my_tunnel'
+          localIdentifier: 'my_tunnel'
         }],
         win32Bin: WIN32_BINARY_DIR
       });
@@ -666,7 +692,7 @@ describe('BrowserStackTunnel', function () {
           name: HOST_NAME,
           port: PORT,
           sslFlag: SSL_FLAG,
-          tunnelIdentifier: 'my_tunnel'
+          localIdentifier: 'my_tunnel'
         }],
         osxBin: OSX_BINARY_DIR
       });
@@ -761,7 +787,7 @@ describe('BrowserStackTunnel', function () {
           name: HOST_NAME,
           port: PORT,
           sslFlag: SSL_FLAG,
-          tunnelIdentifier: 'my_tunnel'
+          localIdentifier: 'my_tunnel'
         }],
         linux64Bin: LINUX_64_BINARY_DIR
       });
@@ -856,7 +882,7 @@ describe('BrowserStackTunnel', function () {
           name: HOST_NAME,
           port: PORT,
           sslFlag: SSL_FLAG,
-          tunnelIdentifier: 'my_tunnel'
+          localIdentifier: 'my_tunnel'
         }],
         linux32Bin: LINUX_32_BINARY_DIR
       });


### PR DESCRIPTION
The options supported by the BrowserStackTunnel binary were very different
from ones supported by the browserstacktunnel-wrapper npm package.

Fix #14
Fix #15
Fix #16
Fix #17
Fix #21

This may require a major version bump but the current options are not working anyway with the bundled binary so...