### PR TITLE
Travis: test on Node 0.12 & io.js, don't test on Node 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
  language: node_js
  node_js:
-   - "0.11"
+   - "iojs"
+   - "0.12"
    - "0.10"
  install:
    - npm update npm -g


### PR DESCRIPTION
Node 0.11 is unstable, it's not worth testing on it. Instead, Node 0.12 & io.js
that are stable should be tested.

Fix #19