### PR TITLE
Prevent EventEmitter memory leaks

### DIFF
--- a/src/BrowserStackTunnel.js
+++ b/src/BrowserStackTunnel.js
@@ -178,9 +178,12 @@ function BrowserStackTunnel(options) {
   };
 
   this.stop = function (callback) {
-    this.once('stop', callback);
-    if (this.state !== 'started') {
-      this.emit('stop', new Error('child not started'));
+    if (this.state !== 'stop' && this.listenerCount('stop') === 0) {
+      this.once('stop', callback);
+    } else if (this.state !== 'started') {
+      var err = new Error('child not started');
+      this.emit('stop', err);
+      callback(err);
     }
 
     this.killTunnel();


### PR DESCRIPTION
The issue #5 can be reproduced by trying to quit karma tests on BrowserStack (using [karma-browserstack-launcher](https://github.com/karma-runner/karma-browserstack-launcher)) prematurely by sending SIGINT events (Ctrl-C) multiple times trying to close the tunnel.

Karma [emits](https://github.com/karma-runner/karma/blob/3c1369b7380e44c1625f08d64b28b07650b4d6f1/lib/server.js#L335) an 'exit' event for each SIGINT event and karma-browserstack-launcher calls [tunnel.stop](https://github.com/karma-runner/karma-browserstack-launcher/blob/999561598a43320c40e78caddcf41d924a646f41/index.js#L48) for each 'exit' event. Hence, 'stop' can be called multiple times, which lead to [multiple listeners](https://github.com/pghalliday/node-BrowserStackTunnel/blob/33d7c24a6c42e7b539cbdad4f1e868ca9bbef7fc/src/BrowserStackTunnel.js#L181) for 'stop' event in the previous code. 

A listener for 'stop event' should only be added if the state of the tunnel is not already 'stop' and there are no previously registered listeners for 'stop' events. This PR addresses that.