### PR TITLE
Use HTTP proxy when downloading tunnel binary.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "child_process"
   ],
   "dependencies": {
+    "https-proxy-agent": "^1.0.0",
     "unzip": "~0.1.9"
   }
 }

--- a/src/BrowserStackTunnel.js
+++ b/src/BrowserStackTunnel.js
@@ -92,7 +92,7 @@ function BrowserStackTunnel(options) {
     console.log('BrowserStackTunnel: binary out of date');
     this.killTunnel();
     var self = this;
-    binary.update(function () {
+    binary.update(options, function () {
       self.startTunnel();
     });
   });
@@ -160,7 +160,7 @@ function BrowserStackTunnel(options) {
     if (!fs.existsSync(binary.path)) {
       console.log('BrowserStackTunnel: binary not present');
       var self = this;
-      binary.update(function () {
+      binary.update(options, function () {
         self._startTunnel();
       });
     } else {

--- a/test/lib/mocks.js
+++ b/test/lib/mocks.js
@@ -60,8 +60,8 @@ var ServerResponse = function () {
 };
 
 var ServerRequest = {
-	get: function(url, callback) {
-		ServerRequest.url = url;
+	get: function(options, callback) {
+		ServerRequest.url = 'https://' + options.hostname + options.path;
 		callback(ServerResponse());
 	}
 };

--- a/test/src/ZipBinary.js
+++ b/test/src/ZipBinary.js
@@ -65,7 +65,7 @@ describe('ZipBinary', function () {
 
     describe('#update', function () {
       it('should download the zip file', function (done) {
-        zipBinary.update(function () {
+        zipBinary.update({}, function () {
           expect(fsMock.fileNameModded).to.equal(DEFAULT_BINARY_FILE);
           expect(fsMock.mode).to.equal('0755');
           expect(unzipMock.dirName).to.equal(DEFAULT_BINARY_DIR);
@@ -77,7 +77,7 @@ describe('ZipBinary', function () {
       describe('with no arch', function () {
         it('should download the zip file', function (done) {
           zipBinary = new ZipBinary(PLATFORM);
-          zipBinary.update(function () {
+          zipBinary.update({}, function () {
             expect(fsMock.fileNameModded).to.equal(DEFAULT_BINARY_FILE_NO_ARCH);
             expect(fsMock.mode).to.equal('0755');
             expect(unzipMock.dirName).to.equal(DEFAULT_BINARY_DIR_NO_ARCH);
@@ -115,7 +115,7 @@ describe('ZipBinary', function () {
 
     describe('#update', function () {
       it('should download the zip file', function (done) {
-        zipBinary.update(function () {
+        zipBinary.update({}, function () {
           expect(fsMock.fileNameModded).to.equal(OTHER_BINARY_FILE);
           expect(fsMock.mode).to.equal('0755');
           expect(unzipMock.dirName).to.equal(OTHER_BINARY_DIR);
@@ -127,7 +127,7 @@ describe('ZipBinary', function () {
       describe('with no arch', function () {
         it('should download the zip file', function (done) {
           zipBinary = new ZipBinary(PLATFORM, null, OTHER_BINARY_DIR);
-          zipBinary.update(function () {
+          zipBinary.update({}, function () {
             expect(fsMock.fileNameModded).to.equal(OTHER_BINARY_FILE);
             expect(fsMock.mode).to.equal('0755');
             expect(unzipMock.dirName).to.equal(OTHER_BINARY_DIR);


### PR DESCRIPTION
Use HTTP proxy when downloading tunnel binary. The proxy config is extracted from the options object.